### PR TITLE
Backend dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,9 @@ dist
 node_modules
 bananaWaffleCookies
 
+# Uploaded Data
+data/
+
 # Logs
 logs
 *.log

--- a/backend/db/documents.go
+++ b/backend/db/documents.go
@@ -1,0 +1,41 @@
+package db
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+)
+
+type Document struct {
+	ID           int       `json:"id"`
+	UserID       int       `json:"user_id"`
+	Title        string    `json:"title"`
+	DocumentType string    `json:"document_type"`
+	IsArchived   bool      `json:"is_archived"`
+	CreatedAt    time.Time `json:"created_at"`
+	UpdatedAt    time.Time `json:"updated_at"`
+}
+
+func CreateDocument(doc Document) (int, error) {
+	var id int
+	sql_query := `INSERT INTO documents (user_id, title, document_type, is_archived) 
+				VALUES ($1, $2, $3, $4) 
+				RETURNING id`
+	err := DbConn.QueryRow(context.Background(), sql_query, doc.UserID, doc.Title, doc.DocumentType, doc.IsArchived).Scan(&id)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to insert job into database: %v\n", err)
+		return -1, err
+	}
+	return id, err
+}
+
+func DeleteDocument(user_id int, doc_id int) error {
+	sql_query := `DELETE FROM documents WHERE id = $1 AND user_id = $2`
+	_, err := DbConn.Exec(context.Background(), sql_query, doc_id, user_id)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to insert job into database: %v\n", err)
+		return err
+	}
+	return nil
+}

--- a/backend/db/documents.go
+++ b/backend/db/documents.go
@@ -24,7 +24,7 @@ func CreateDocument(doc Document) (int, error) {
 				RETURNING id`
 	err := DbConn.QueryRow(context.Background(), sql_query, doc.UserID, doc.Title, doc.DocumentType, doc.IsArchived).Scan(&id)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to insert job into database: %v\n", err)
+		fmt.Fprintf(os.Stderr, "Failed to insert document into database: %v\n", err)
 		return -1, err
 	}
 	return id, err
@@ -34,7 +34,7 @@ func DeleteDocument(user_id int, doc_id int) error {
 	sql_query := `DELETE FROM documents WHERE id = $1 AND user_id = $2`
 	_, err := DbConn.Exec(context.Background(), sql_query, doc_id, user_id)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to insert job into database: %v\n", err)
+		fmt.Fprintf(os.Stderr, "Failed to remove document from database: %v\n", err)
 		return err
 	}
 	return nil

--- a/backend/db/documents.go
+++ b/backend/db/documents.go
@@ -52,9 +52,9 @@ func UpdateDocument(doc Document) error {
 	return nil
 }
 
-func GetDocument(doc_id int) (Document, error) {
+func GetDocument(doc_id int, user_id int) (Document, error) {
 	var doc Document
-	err := DbConn.QueryRow(context.Background(), "SELECT id, user_id, title, document_type, is_archived, created_at, updated_at FROM documents WHERE id=$1", doc_id).Scan(&doc.ID, &doc.UserID, &doc.Title, &doc.DocumentType, &doc.IsArchived, &doc.CreatedAt, &doc.UpdatedAt)
+	err := DbConn.QueryRow(context.Background(), "SELECT id, user_id, title, document_type, is_archived, created_at, updated_at FROM documents WHERE id=$1 AND user_id = $2", doc_id, user_id).Scan(&doc.ID, &doc.UserID, &doc.Title, &doc.DocumentType, &doc.IsArchived, &doc.CreatedAt, &doc.UpdatedAt)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to retrieve document from Database: %v\n", err)
 		return Document{}, err

--- a/backend/db/documents.go
+++ b/backend/db/documents.go
@@ -39,3 +39,15 @@ func DeleteDocument(user_id int, doc_id int) error {
 	}
 	return nil
 }
+
+func UpdateDocument(doc Document) error {
+	sql_query := `UPDATE documents
+		      SET title = $1, document_type = $2, is_archived = $3
+		      WHERE id = $4 AND user_id = $5`
+	_, err := DbConn.Exec(context.Background(), sql_query, doc.Title, doc.DocumentType, doc.IsArchived, doc.ID, doc.UserID)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to update document in Database: %v\n", err)
+		return err
+	}
+	return nil
+}

--- a/backend/db/documents.go
+++ b/backend/db/documents.go
@@ -51,3 +51,13 @@ func UpdateDocument(doc Document) error {
 	}
 	return nil
 }
+
+func GetDocument(doc_id int) (Document, error) {
+	var doc Document
+	err := DbConn.QueryRow(context.Background(), "SELECT id, user_id, title, document_type, is_archived, created_at, updated_at FROM documents WHERE id=$1", doc_id).Scan(&doc.ID, &doc.UserID, &doc.Title, &doc.DocumentType, &doc.IsArchived, &doc.CreatedAt, &doc.UpdatedAt)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to retrieve document from Database: %v\n", err)
+		return Document{}, err
+	}
+	return doc, nil
+}

--- a/backend/handlers/documents.go
+++ b/backend/handlers/documents.go
@@ -12,6 +12,7 @@ import (
 	"github.com/go-chi/chi/v5"
 )
 
+// Handler for /api/documents (POST)
 func UploadDocument(w http.ResponseWriter, r *http.Request) {
 	var tokenInfo Claim
 	err, tokenInfo := GrabToken(r)
@@ -79,6 +80,7 @@ func UploadDocument(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(doc)
 }
 
+// Handler for /api/documents/{id} (DELETE)
 func DeleteDocument(w http.ResponseWriter, r *http.Request) {
 	err, tokenInfo := GrabToken(r)
 	if err != nil {
@@ -98,6 +100,7 @@ func DeleteDocument(w http.ResponseWriter, r *http.Request) {
 	err = db.DeleteDocument(tokenInfo.Uid, doc_id)
 }
 
+// Handler for /api/documents/{id} (PUT)
 func UpdateDocument(w http.ResponseWriter, r *http.Request) {
 	var tokenInfo Claim
 	err, tokenInfo := GrabToken(r)

--- a/backend/handlers/documents.go
+++ b/backend/handlers/documents.go
@@ -1,0 +1,99 @@
+package handlers
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strconv"
+
+	"bananawafflecookies.com/m/v2/db"
+	"github.com/go-chi/chi/v5"
+)
+
+func UploadDocument(w http.ResponseWriter, r *http.Request) {
+	var tokenInfo Claim
+	err, tokenInfo := GrabToken(r)
+	if err != nil {
+		http.Error(w, "Failed to upload document", http.StatusBadRequest)
+		fmt.Fprintf(os.Stderr, "Failed to upload document; Failed to grab auth token information: %v\n", err)
+		return
+	}
+
+	file, fileHeader, err := r.FormFile("file")
+	if err != nil {
+		http.Error(w, "Failed to upload document", http.StatusBadRequest)
+		fmt.Fprintf(os.Stderr, "Failed to upload document; Failed to grab file from request: %v\n", err)
+		return
+	}
+	defer file.Close()
+
+	buffer := make([]byte, 512)
+	_, err = file.Read(buffer)
+	if err != nil {
+		http.Error(w, "Failed to parse document type", http.StatusBadRequest)
+		fmt.Fprintf(os.Stderr, "Failed to parse document type: %v\n", err)
+		return
+	}
+
+	doc := db.Document{
+		UserID:       tokenInfo.Uid,
+		Title:        fileHeader.Filename,
+		DocumentType: "resume",
+		IsArchived:   false,
+	}
+
+	id, err := db.CreateDocument(doc)
+	doc.ID = id
+
+	if err != nil {
+		http.Error(w, "Failed to upload document", http.StatusBadRequest)
+		fmt.Fprintf(os.Stderr, "Failed to upload document; Failed to create document entry in DB: %v\n", err)
+		return
+	}
+
+	dst := fmt.Sprintf("./data/documents/%d.pdf", id)
+	out, err := os.Create(dst)
+	if err != nil {
+		http.Error(w, "Failed to upload document", http.StatusInternalServerError)
+		fmt.Fprintf(os.Stderr, "Failed to upload document; Failed to create file destination: %v\n", err)
+		if err = db.DeleteDocument(tokenInfo.Uid, doc.ID); err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to delete document %s (ID: %d) from database: %v\n", doc.Title, doc.ID, err)
+		}
+		return
+	}
+
+	defer out.Close()
+	_, err = io.Copy(out, file)
+	if err != nil {
+		http.Error(w, "Failed to upload document", http.StatusInternalServerError)
+		fmt.Fprintf(os.Stderr, "Failed to upload document; Failed to copy file to destination: %v\n", err)
+		if err = db.DeleteDocument(tokenInfo.Uid, doc.ID); err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to delete document %s (ID: %d) from database: %v\n", doc.Title, doc.ID, err)
+		}
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(doc)
+}
+
+func DeleteDocument(w http.ResponseWriter, r *http.Request) {
+	err, tokenInfo := GrabToken(r)
+	if err != nil {
+		http.Error(w, "Failed to delete document", http.StatusBadRequest)
+		fmt.Fprintf(os.Stderr, "Failed to delete document; Failed to grab auth token information: %v\n", err)
+		return
+	}
+
+	doc_id_raw := chi.URLParam(r, "id")
+
+	doc_id, err := strconv.Atoi(doc_id_raw)
+	if err != nil {
+		http.Error(w, "Failed to delete document", http.StatusInternalServerError)
+		fmt.Fprintf(os.Stderr, "Failed to delete document: Failed to convert document id into integer: %v\n", err)
+		return
+	}
+	err = db.DeleteDocument(tokenInfo.Uid, doc_id)
+}

--- a/backend/handlers/documents.go
+++ b/backend/handlers/documents.go
@@ -97,3 +97,114 @@ func DeleteDocument(w http.ResponseWriter, r *http.Request) {
 	}
 	err = db.DeleteDocument(tokenInfo.Uid, doc_id)
 }
+
+func UpdateDocument(w http.ResponseWriter, r *http.Request) {
+	var tokenInfo Claim
+	err, tokenInfo := GrabToken(r)
+	if err != nil {
+		http.Error(w, "Failed to upload document", http.StatusBadRequest)
+		fmt.Fprintf(os.Stderr, "Failed to upload document; Failed to grab auth token information: %v\n", err)
+		return
+	}
+
+	file, fileHeader, err := r.FormFile("file")
+	if err != nil {
+		http.Error(w, "Failed to upload document", http.StatusBadRequest)
+		fmt.Fprintf(os.Stderr, "Failed to upload document; Failed to grab file from request: %v\n", err)
+		return
+	}
+	defer file.Close()
+
+	buffer := make([]byte, 512)
+	_, err = file.Read(buffer)
+	if err != nil {
+		http.Error(w, "Failed to parse document type", http.StatusBadRequest)
+		fmt.Fprintf(os.Stderr, "Failed to parse document type: %v\n", err)
+		return
+	}
+
+	doc := db.Document{
+		UserID:       tokenInfo.Uid,
+		Title:        fileHeader.Filename,
+		DocumentType: "resume",
+		IsArchived:   false,
+	}
+
+	err = db.UpdateDocument(doc)
+	if err != nil {
+		http.Error(w, "Failed to update document", http.StatusBadRequest)
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+	}
+}
+
+// Handler for /api/documents/{id} (GET)
+func GetDocument(w http.ResponseWriter, r *http.Request) {
+	doc_id_raw := chi.URLParam(r, "id")
+
+	doc_id, err := strconv.Atoi(doc_id_raw)
+	if err != nil {
+		http.Error(w, "Failed to get document", http.StatusInternalServerError)
+		fmt.Fprintf(os.Stderr, "Failed to get document; Failed to convert user id into integer: %v\n", err)
+		return
+	}
+
+	doc, err := db.GetDocument(doc_id)
+
+	if err != nil {
+		http.Error(w, "Failed to get document", http.StatusBadRequest)
+		fmt.Fprintf(os.Stderr, "Failed to get document: %v\n", err)
+		return
+	}
+
+	// Grab document file
+	filePath := fmt.Sprintf("./data/documents/%d.pdf", doc_id)
+	file, err := os.Open(filePath)
+	if err != nil {
+		http.Error(w, "Failed to get document", http.StatusNotFound)
+		fmt.Fprintf(os.Stderr, "Failed to get document; Failed to open document file: %v\n", err)
+		return
+	}
+	defer file.Close()
+
+	// Get file's stats
+	stat, err := file.Stat()
+	if err != nil {
+		http.Error(w, "Failed to get document", http.StatusInternalServerError)
+		fmt.Fprintf(os.Stderr, "Failed to get document; Failed to stat file: %v\n", err)
+		return
+	}
+
+	// Set headers
+	w.Header().Set("Content-Type", "application/pdf")
+	w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"`, doc.Title))
+	w.Header().Set("Content-Length", strconv.FormatInt(stat.Size(), 10))
+
+	// Stream file to requesting user
+	_, err = io.Copy(w, file)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to send file: %v\n", err)
+	}
+}
+
+// Handler for /api/documents/{id}/info (GET)
+func GetDocumentInfo(w http.ResponseWriter, r *http.Request) {
+	doc_id_raw := chi.URLParam(r, "id")
+
+	doc_id, err := strconv.Atoi(doc_id_raw)
+	if err != nil {
+		http.Error(w, "Failed to get document", http.StatusInternalServerError)
+		fmt.Fprintf(os.Stderr, "Failed to get document; Failed to convert user id into integer: %v\n", err)
+		return
+	}
+
+	doc, err := db.GetDocument(doc_id)
+
+	if err != nil {
+		http.Error(w, "Failed to get document", http.StatusBadRequest)
+		fmt.Fprintf(os.Stderr, "Failed to get document: %v\n", err)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(doc)
+}

--- a/backend/handlers/documents.go
+++ b/backend/handlers/documents.go
@@ -142,6 +142,14 @@ func UpdateDocument(w http.ResponseWriter, r *http.Request) {
 
 // Handler for /api/documents/{id} (GET)
 func GetDocument(w http.ResponseWriter, r *http.Request) {
+	var tokenInfo Claim
+	err, tokenInfo := GrabToken(r)
+	if err != nil {
+		http.Error(w, "Failed to upload document", http.StatusBadRequest)
+		fmt.Fprintf(os.Stderr, "Failed to upload document; Failed to grab auth token information: %v\n", err)
+		return
+	}
+
 	doc_id_raw := chi.URLParam(r, "id")
 
 	doc_id, err := strconv.Atoi(doc_id_raw)
@@ -151,7 +159,7 @@ func GetDocument(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	doc, err := db.GetDocument(doc_id)
+	doc, err := db.GetDocument(doc_id, tokenInfo.Uid)
 
 	if err != nil {
 		http.Error(w, "Failed to get document", http.StatusBadRequest)
@@ -191,6 +199,14 @@ func GetDocument(w http.ResponseWriter, r *http.Request) {
 
 // Handler for /api/documents/{id}/info (GET)
 func GetDocumentInfo(w http.ResponseWriter, r *http.Request) {
+	var tokenInfo Claim
+	err, tokenInfo := GrabToken(r)
+	if err != nil {
+		http.Error(w, "Failed to upload document", http.StatusBadRequest)
+		fmt.Fprintf(os.Stderr, "Failed to upload document; Failed to grab auth token information: %v\n", err)
+		return
+	}
+
 	doc_id_raw := chi.URLParam(r, "id")
 
 	doc_id, err := strconv.Atoi(doc_id_raw)
@@ -200,7 +216,7 @@ func GetDocumentInfo(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	doc, err := db.GetDocument(doc_id)
+	doc, err := db.GetDocument(doc_id, tokenInfo.Uid)
 
 	if err != nil {
 		http.Error(w, "Failed to get document", http.StatusBadRequest)

--- a/backend/main.go
+++ b/backend/main.go
@@ -47,6 +47,8 @@ func main() {
 		r.Put("/api/jobs", handlers.UpdateJob)
 		r.Put("/api/settings", handlers.UpdateSettings)
 		r.Get("/api/settings", handlers.GetSettings)
+		r.Post("/api/documents", handlers.UploadDocument)
+		r.Delete("/api/documents/{id}", handlers.DeleteDocument)
 	})
 
 	// Serve frontend for Vue routes

--- a/backend/main.go
+++ b/backend/main.go
@@ -37,16 +37,16 @@ func init() {
 	err := db.InitDB()
 	if err != nil {
 		log.Fatalf(`Failed to init database: %v`, err)
+	}
 
 	// Create data folder
-	err := os.MkdirAll("data", 0750)
+	err = os.MkdirAll("data", 0750)
 	if err != nil && err != fs.ErrExist {
 		log.Fatalf("Failed to create data directory: %s\n", err)
 	}
 	err = os.MkdirAll("data/documents", 0750)
 	if err != nil && err != fs.ErrExist {
 		log.Fatalf("Failed to create data/documents directory: %s\n", err)
-
 	}
 }
 

--- a/backend/main.go
+++ b/backend/main.go
@@ -3,8 +3,10 @@ package main
 import (
 	"flag"
 	"fmt"
+	"io/fs"
 	"log"
 	"net/http"
+	"os"
 
 	"bananawafflecookies.com/m/v2/handlers"
 	"github.com/go-chi/chi/v5"
@@ -23,6 +25,16 @@ func setup() {
 	config.dev = flag.Bool("dev", false, "run in development mode")
 	config.port = flag.Int("p", 8080, "port to run server on")
 	flag.Parse()
+
+	// Create data folder
+	err := os.MkdirAll("data", 0750)
+	if err != nil && err != fs.ErrExist {
+		log.Fatalf("Failed to create data directory: %s\n", err)
+	}
+	err = os.MkdirAll("data/documents", 0750)
+	if err != nil && err != fs.ErrExist {
+		log.Fatalf("Failed to create data/documents directory: %s\n", err)
+	}
 }
 
 func main() {

--- a/backend/main.go
+++ b/backend/main.go
@@ -59,8 +59,11 @@ func main() {
 		r.Put("/api/jobs", handlers.UpdateJob)
 		r.Put("/api/settings", handlers.UpdateSettings)
 		r.Get("/api/settings", handlers.GetSettings)
+		r.Get("/api/documents/{id}", handlers.GetDocument)
+		r.Get("/api/documents/{id}/info", handlers.GetDocumentInfo)
 		r.Post("/api/documents", handlers.UploadDocument)
 		r.Delete("/api/documents/{id}", handlers.DeleteDocument)
+		r.Put("/api/documents/{id}", handlers.UpdateDocument)
 	})
 
 	// Serve frontend for Vue routes

--- a/frontend/src/pages/library.vue
+++ b/frontend/src/pages/library.vue
@@ -86,9 +86,10 @@ async function uploadFile() {
     const formData = new FormData()
     formData.append('file', selectedFile.value)
 
-    const res = await fetch('/api/documents/upload', {
+    const res = await fetch('/api/documents', {
       method: 'POST',
-      body: formData
+      body: formData,
+      credentials: 'include'
     })
 
     if (res.ok) {
@@ -97,9 +98,9 @@ async function uploadFile() {
       // backend response
       documents.value.push({
         id: data.id,
-        title: data.name,
-        type: data.type || 'File',
-        url: data.url
+        title: data.title,
+        type: data.document_type || 'File',
+        url: "/documents/{id}" + document.id
       })
 
       uploadMessage.value = 'File uploaded successfully!'
@@ -128,7 +129,8 @@ async function deleteDocument(id) {
 
   try {
     const res = await fetch(`/api/documents/${id}`, {
-      method: 'DELETE'
+      method: 'DELETE',
+      credentials: 'include'
     })
 
     if (res.ok) {

--- a/schemas/db_up.sql
+++ b/schemas/db_up.sql
@@ -147,7 +147,7 @@ CREATE TABLE IF NOT EXISTS job_activities (
 CREATE TABLE IF NOT EXISTS documents (
     id BIGSERIAL PRIMARY KEY,
     user_id BIGINT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-    name TEXT NOT NULL,
+    title TEXT NOT NULL,
     document_type TEXT NOT NULL CHECK (
         document_type IN ('resume', 'cover_letter', 'other')
     ),


### PR DESCRIPTION
Base backend/frontend for documents api.

Backend includes the following paths;
- `GET /api/documents/{id}`: Returns the document file itself
- `GET /api/documents/{id}/info`: Returns a JSON object of the information about the document stored in the DB
 - `POST /api/documents`: Uploads a document 
- `DELETE /api/documents`: Deletes a user-owned document
- `PUT /api/documents/{id}`: Updates the information stored in the db about a document (but doesn't replace the document itself). 

Frontend includes the following:
- Document upload page

NOT IMPLEMENTED:
1. A way for users to select document type when uploading the file (rn I just have everything considered as a "resume")
2. Limit on frontend & backend filetype (should only be PDFs I think)
3. Frontend pages where uses can view info about a document, see all a list of all their documents,  update info about their documents, and delete their documents 